### PR TITLE
Implement matching files to suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Parallel test amazing things (someday this currently does very little).
 ## TODO:
 
   - [x] Recursive manifest loading.
-  - []  Match files to suites
+  - [x] Match files to suites
   - []  Match suites to files
   - []  Execution of files in suites.
   - []  Parallel execution of files.

--- a/src/overlord/config.rs
+++ b/src/overlord/config.rs
@@ -1,18 +1,142 @@
 // This module contains the he canonical interfaaces used by all internal
 // operations in overlord it may or may not conform to the same format as the
 // user facing interchange format.
+use util::{PathWrapper};
+use glob::{Pattern, MatchOptions};
+use std::fmt::{FormatError, Formatter, Show};
+use std::cmp::{PartialEq};
+
+// A suite "path" is a level of indirection around a glob pattern with show
+// funcitonality and a constructor geared towards overlord specific path
+// matching.
+pub struct SuitePath {
+  // Actual glob pattern used to match the path.
+  pub pattern: Pattern,
+
+  // Human readable path
+  pub path: String
+}
+
+impl SuitePath {
+  pub fn new(root: &PathWrapper, path: String) -> SuitePath {
+    // This is probably a hack but is the most convient way to join the
+    // strings. A potential problem here is if the "glob" pattern somehow
+    // messes up the join. Another issue is the use of `..` in paths...
+    let joined = root.get().join(Path::new(path.clone()));
+    let joined_str = joined.as_str().unwrap();
+    let joined_path = joined_str.to_string();
+
+    SuitePath {
+      // unwrap is somewhat lazy here but doing this "correctly" is more work
+      // and make the signature uglier.
+      pattern: Pattern::new(joined_str),
+      path: joined_path
+    }
+  }
+}
+
+// For tests we need the ability to assert equality...
+impl PartialEq for SuitePath {
+  fn eq(&self, other: &SuitePath) -> bool {
+    self.path == other.path
+  }
+}
+
+// For nice output we still show the same value as we get from the raw
+// configuration
+impl Show for SuitePath {
+  fn fmt(&self, f: &mut Formatter) -> Result<(), FormatError> {
+    self.path.fmt(f)
+  }
+}
 
 // All operations stem from the "suite" configuration.
+#[deriving(PartialEq, Show)]
 pub struct Suite<'a> {
   /// Name of the "group" this suite belongs to.
   pub group: String,
 
   /// The Path in which to conduct matching of files, etc...
-  pub root: Path,
+  pub root: PathWrapper,
 
   /// A list of "paths" (may also be globs) for the suite.
-  pub paths: Vec<String>,
+  pub paths: Vec<SuitePath>,
 
   /// The executable to use to run files for this suite.
   pub executable: String
+}
+
+
+impl<'a> Suite<'a> {
+  /// Determine if a given file matches any of the "path" pattern rules in this
+  /// suite.
+  pub fn contains_path(&self, path: &Path) -> bool {
+    // These options are used so frequently it would make sense to stash them
+    // somewhere higher up likely...
+    let match_options = MatchOptions {
+      case_sensitive: true,
+      // Do not match into subdirectories implicitly
+      require_literal_separator: true,
+      require_literal_leading_dot: false
+    };
+
+
+    for suite_path in self.paths.iter() {
+      let matches = suite_path.pattern.matches_path_with(path, match_options);
+      if matches {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use util::{PathWrapper};
+  use super::{SuitePath, Suite};
+
+  fn get_suite<'a>() -> Suite<'a> {
+    let root = PathWrapper::from_str("/foo");
+    let paths = vec![
+      SuitePath::new(&root, "*_test.txt".to_string()),
+      SuitePath::new(&root, "nested/bar/*_test.txt".to_string()),
+    ];
+
+    Suite {
+      group: "xfoo".to_string(),
+      root: root,
+      paths: paths,
+      executable: "cat".to_string()
+    }
+  }
+
+  #[test]
+  fn new_suite_path() {
+    let subject =
+      SuitePath::new(&PathWrapper::from_str("/User/foo"), "*.txt".to_string());
+
+    // Quick sanity check to ensure pattern matching is working from the correct
+    // root.
+    assert!(subject.pattern.matches("/User/foo/xfoo.txt"));
+    assert_eq!(subject.pattern.matches("/User/foo/xfoo.js"), false);
+    assert_eq!(subject.pattern.matches("xfoo.txt"), false);
+  }
+
+  #[test]
+  fn suite_path_matches_none() {
+    let suite = get_suite();
+    assert_eq!(
+      suite.contains_path(&Path::new("/foo/other/file_test.txt")), false
+    );
+  }
+
+  #[test]
+  fn suite_path_matches() {
+    let suite = get_suite();
+    assert!(suite.contains_path(&Path::new("/foo/1_test.txt")));
+    assert!(suite.contains_path(&Path::new("/foo/2_test.txt")));
+    assert!(suite.contains_path(&Path::new("/foo/nested/bar/1_test.txt")));
+    assert!(suite.contains_path(&Path::new("/foo/nested/bar/2_test.txt")));
+  }
 }

--- a/src/overlord/lib.rs
+++ b/src/overlord/lib.rs
@@ -11,6 +11,8 @@ pub mod error;
 pub mod config;
 pub mod interchange;
 pub mod config_loader;
+pub mod path_identifier;
+pub mod util;
 //pub mod config;
 //pub mod suite;
 //pub mod manifest;

--- a/src/overlord/path_identifier.rs
+++ b/src/overlord/path_identifier.rs
@@ -1,0 +1,125 @@
+// Paths to suites are matched here...
+use config::{Suite};
+
+pub fn identify<'a>(
+  path: &Path, suites: &'a Vec<Suite>
+) -> Option<&'a Suite<'a>> {
+
+  // Deepest meaning the mosted nested in the file system (but with the correct
+  // ancestry).
+  let mut deepest: Option<&Suite> = None;
+
+  for suite in suites.iter() {
+    let root_path = suite.root.get();
+
+    // Rule out any suites which could not possibly match.
+    if !root_path.is_ancestor_of(path) {
+      continue
+    }
+
+    // If this was the first iteration continue to the next for comparision.
+    if deepest.is_none() {
+      deepest = Some(suite);
+      continue
+    }
+
+    // If the root path is greater then it is now the new deepest entry.
+    if root_path > deepest.unwrap().root.get() {
+      deepest = Some(suite);
+    }
+  };
+
+  // No suite was even a close match based on roots.
+  if deepest.is_none() {
+    return None;
+  }
+
+  // We have the closest suite by root check if any of the paths match.
+  let suite = deepest.unwrap();
+  if suite.contains_path(path) {
+    Some(suite)
+  } else {
+    None
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use config::{Suite, SuitePath};
+  use util::{PathWrapper};
+  use super::{identify};
+
+  fn get_suite(root_path: &str) -> Suite {
+    let root = PathWrapper::from_str(root_path);
+    let paths = vec![SuitePath::new(&root, "*.txt".to_string())];
+    Suite {
+      group: "xfoo".to_string(),
+      root: root,
+      paths: paths,
+      executable: "cat".to_string()
+    }
+  }
+
+  fn get_suites(root_paths: Vec<&str>) -> Vec<Suite> {
+    root_paths.iter().map(|root_path| {
+      get_suite(*root_path)
+    }).collect()
+  }
+
+  // Find a single suite by root note that this will fail the task rather then
+  // using an option since it's easier and clearer for testing.
+  fn suite_by_root<'a>(
+    root_path: &str, suites: &'a Vec<Suite>
+  ) -> &'a Suite<'a> {
+
+    let root = PathWrapper::from_str(root_path);
+    suites.iter().find(|suite| {
+      suite.root == root
+    }).unwrap()
+  }
+
+  #[test]
+  fn identify_found_single_root() {
+    let suites = get_suites(vec!["/find_me"]);
+    let path = Path::new("/find_me/woot.txt");
+    assert_eq!(
+      identify(&path, &suites).unwrap(), suite_by_root("/find_me", &suites)
+    );
+  }
+
+  #[test]
+  fn identify_found_closest_root() {
+    let suites = get_suites(vec!["/find_me/level/1/two", "/find_me/level/1/"]);
+
+    let path = Path::new("/find_me/level/1/woot.txt");
+    assert_eq!(
+      identify(&path, &suites).unwrap(),
+      suite_by_root("/find_me/level/1/", &suites)
+    );
+  }
+
+  #[test]
+  fn identify_found_deepest_root() {
+    let suites = get_suites(vec!["/find_me/level/1/two", "/find_me/level/1/"]);
+
+    let path = Path::new("/find_me/level/1/two/woot.txt");
+    assert_eq!(
+      identify(&path, &suites).unwrap(),
+      suite_by_root("/find_me/level/1/two", &suites)
+    );
+  }
+
+  #[test]
+  fn identify_none_file_mismatch() {
+    let suites = get_suites(vec!["/foo"]);
+    let path = Path::new("/foo/another-thing");
+    assert_eq!(identify(&path, &suites), None)
+  }
+
+  #[test]
+  fn identify_none_root_mismatch() {
+    let suites = get_suites(vec!["/bar"]);
+    let path = Path::new("/foo/xfoo.txt");
+    assert_eq!(identify(&path, &suites), None)
+  }
+}

--- a/src/overlord/test.rs
+++ b/src/overlord/test.rs
@@ -1,4 +1,9 @@
 use std::os;
+use util::{PathWrapper};
+
+pub fn assert_path_wrapper_eq(expected: &Path, actual: &PathWrapper) {
+  assert_path_eq(expected, &os::make_absolute(actual.get()))
+}
 
 pub fn assert_path_eq(expected: &Path, actual: &Path) {
   let abs_expected = os::make_absolute(expected);

--- a/src/overlord/util.rs
+++ b/src/overlord/util.rs
@@ -1,0 +1,31 @@
+// Generic utils for rust and not specific to core Overlord functionality... The
+// intent is these utilities will either be replaced, moved or become useless...
+use std::fmt::{Show, Formatter, FormatError};
+
+// A single layer of indirection around a path simply so we can
+#[deriving(PartialEq)]
+pub struct PathWrapper {
+  value: Path
+}
+
+impl PathWrapper {
+  pub fn get(&self) -> &Path {
+    return &self.value
+  }
+
+  pub fn from_str(path: &str) -> PathWrapper {
+    PathWrapper { value: Path::new(path) }
+  }
+
+  pub fn new(path: Path) -> PathWrapper {
+    PathWrapper { value: path }
+  }
+}
+
+// Important bit of PathSrc here is the ability to "show" the path this is
+// hugely useful for tests and to display errors, etc..
+impl Show for PathWrapper {
+  fn fmt(&self, f: &mut Formatter) -> Result<(), FormatError> {
+    self.value.display().fmt(f)
+  }
+}


### PR DESCRIPTION
This adds the "glob" based pattern matching so overlord can map files to suites. Path matching should be moderately smart as we find the "deepest" root in which the path could possibly be located.

An example:

Roots:
`/a/b/`
`/a/b/c/d`
`/a/b/c`
`/a/b/c/d/e/f/g`

If your path is something like`/a/b/c/foo_test.js` we will only search the patterns of /a/b/c (globs should be the slowest part of this so we attempt to only use them in the folders we need to).

Also made changes to the `config.Suite` struct so pattern matching was both a little more sensible and the struct is now "Show"able so things like println!("{}", suite) work as intended.
